### PR TITLE
Set X-Forwarded-Port

### DIFF
--- a/templates/server.conf.erb
+++ b/templates/server.conf.erb
@@ -39,6 +39,7 @@ server {
     proxy_set_header X-Real-IP         $proxy_protocol_addr;
     proxy_set_header X-Forwarded-For   $proxy_protocol_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port  $proxy_protocol_port;
     proxy_set_header Host $http_host;
     proxy_redirect off;
 


### PR DESCRIPTION
I think some application will need this too when it require the information of the connection from client.

For example, [Rack::Request#port](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L238) will return 80 even if proxy accepts request on non-standard port. And [OmniAuth has similar problem](http://stackoverflow.com/questions/6803307/omniauth-using-wrong-callback-port-in-a-reverse-proxy-setup#7135029).



